### PR TITLE
Fix ‘getSketchVersion’ util

### DIFF
--- a/lib/utils/getSketchVersion.js
+++ b/lib/utils/getSketchVersion.js
@@ -1,4 +1,4 @@
-var config = require('./utils/config').get()
+var config = require('./config').get()
 var exec = require('./exec').exec
 
 module.exports = function () {


### PR DESCRIPTION
The require call to the `config` util used the wrong path, so requiring `getSketchVersion` resulted in an error, which was affecting the `install` and `link` commands.