### PR TITLE
Fix running on Sketch 44+

### DIFF
--- a/lib/skpm-build.js
+++ b/lib/skpm-build.js
@@ -9,6 +9,7 @@ var uniqBy = require('lodash.uniqby')
 var objectAssign = require('object-assign')
 var generateWebpackConfig = require('./utils/webpackConfig')
 var getRepoFromPackageJSON = require('./utils/getRepoFromPackageJSON')
+var getSketchVersion = require('./utils/getSketchVersion')
 
 var buildEmojis = ['🔧', '🔨', '⚒', '🛠', '⛏', '🔩']
 function randomBuildEmoji () {
@@ -166,14 +167,16 @@ function buildCallback (file, watching) {
   }
 }
 
-commands.concat(packageJSON.resources || []).forEach(function (command) {
-  var file = command.script || command
-  const compiler = webpack(webpackConfig(file, command.identifier))
-  if (program.watch) {
-    compiler.watch({}, buildCallback(file, program.watch))
-  } else {
-    compiler.run(buildCallback(file, program.watch))
-  }
+getSketchVersion().then(function (sketchVersion) {
+  commands.concat(packageJSON.resources || []).forEach(function (command) {
+    var file = command.script || command
+    const compiler = webpack(webpackConfig(file, command.identifier, sketchVersion))
+    if (program.watch) {
+      compiler.watch({}, buildCallback(file, program.watch))
+    } else {
+      compiler.run(buildCallback(file, program.watch))
+    }
+  })
 })
 
 var now = Date.now()

--- a/lib/utils/exec.js
+++ b/lib/utils/exec.js
@@ -14,6 +14,20 @@ module.exports.exec = function (command, options) {
   })
 }
 
+module.exports.execFile = function (command, options) {
+  return new Promise(function (resolve, reject) {
+    childProcess.execFile(command, options, function (error, stdout, stderr) {
+      if (error) {
+        return reject(error)
+      }
+      resolve({
+        stdout: stdout,
+        stderr: stderr
+      })
+    })
+  })
+}
+
 module.exports.spawn = function (command, args, options) {
   return new Promise(function (resolve, reject) {
     var child = childProcess.spawn(command, args, {

--- a/lib/utils/getSketchVersion.js
+++ b/lib/utils/getSketchVersion.js
@@ -1,19 +1,24 @@
 var config = require('./config').get()
-var exec = require('./exec').exec
+var execFile = require('./exec').execFile
+var path = require('path')
 
+function extractVersion(string) {
+  var regex = /sketchtool Version ([\d|\.]+) \(\d+\)/
+  return regex.exec(string)[1];
+}
 module.exports = function () {
-  return exec(config.sketchPatch + '/Contents/Resources/sketchtool/bin/sketchtool -v')
-    .then(function (version) {
-      version = String(parseFloat(version.replace('sketchtool Version ', '')))
-      var pointNumbers = version.split('.').length
-      if (pointNumbers === 0) {
-        version = version + '.0.0'
-      } else if (pointNumbers === 1) {
-        version = version + '.0'
-      }
-      return version
-    })
-    .catch(function () {
-      return undefined
-    })
+  return execFile(path.join(config.sketchPath, '/Contents/Resources/sketchtool/bin/sketchtool'), ['-v'])
+  .then(function ({ stdout, stderr }) {
+    var version = extractVersion(stdout)
+    var pointNumbers = version.split('.').length
+    if (pointNumbers === 1) {
+      version = version + '.0.0'
+    } else if (pointNumbers === 2) {
+      version = version + '.0'
+    }
+    return version
+  })
+  .catch(function () {
+    return undefined
+  })
 }

--- a/lib/utils/getSketchVersion.js
+++ b/lib/utils/getSketchVersion.js
@@ -2,9 +2,9 @@ var config = require('./config').get()
 var execFile = require('./exec').execFile
 var path = require('path')
 
-function extractVersion(string) {
-  var regex = /sketchtool Version ([\d|\.]+) \(\d+\)/
-  return regex.exec(string)[1];
+function extractVersion (string) {
+  var regex = /sketchtool Version ((\d|\.)+) \(\d+\)/
+  return regex.exec(string)[1]
 }
 module.exports = function () {
   return execFile(path.join(config.sketchPath, '/Contents/Resources/sketchtool/bin/sketchtool'), ['-v'])

--- a/lib/utils/webpackConfig.js
+++ b/lib/utils/webpackConfig.js
@@ -2,8 +2,11 @@ var fs = require('fs')
 var path = require('path')
 var chalk = require('chalk')
 var webpack = require('webpack')
+var WebpackShellPlugin = require('./webpackShellPlugin')
 var SketchCommandPlugin = require('./sketchCommandPlugin')
 var objectAssign = require('object-assign')
+var config = require('../utils/config').get()
+var semver = require('semver')
 
 function babelLoader (userDefinedBabelConfig) {
   var options = {
@@ -27,6 +30,54 @@ function babelLoader (userDefinedBabelConfig) {
       options: options
     }
   }
+}
+
+function sketchtoolRunCommand (output, commandIdentifier, withoutActivating) {
+  var command = `"${config.sketchPath}/Contents/Resources/sketchtool/bin/sketchtool" run "${output}" "${commandIdentifier}"`
+
+  if (withoutActivating) {
+    command += ' --without-activating'
+  }
+
+  var handleError = (
+    // check if the run command doesn't exist
+    'if (echo "$res" | grep "Unknown command ‘run’"); then ' +
+    'echo "Only available on Sketch 43+"; ' +
+    // check if we can't find sketch
+    'elif (echo "$res" | grep "such file or directory"); then ' +
+    'echo "Looks like we can\'t find Sketch.app.\\nYou can specify where to look for it by running:\\n\\necho \\"sketchPath: ABSOLUTE/PATH/TO/Sketch.app\\" > ~/.skpmrc"; ' +
+    // not sure why else doesn't work
+    'elif (true); then ' +
+    'echo "$res"; ' +
+    'fi'
+  )
+
+  // run the command and redirect the stderr to stdout so that we can check against it
+  return `res=$(${command} 2>&1); ${handleError}`
+}
+
+function getCommand (output, commandIdentifier, sketchVersion) {
+  var command
+  if (semver.satisfies(sketchVersion, '^43.0.0')) {
+    command = new SketchCommandPlugin({
+      bundleURL: output,
+      commandIdentifier
+    })
+  }
+
+  if (semver.satisfies(sketchVersion, '^44.0.0')) {
+    command = new WebpackShellPlugin({
+      script: sketchtoolRunCommand(output, commandIdentifier)
+    })
+  }
+
+  if (semver.satisfies(sketchVersion, '>= 45.0.0')) {
+    command = new WebpackShellPlugin({
+      script: sketchtoolRunCommand(output, commandIdentifier, true)
+    })
+  }
+
+  return command
 }
 
 module.exports = function (program, output, manifestFolder, packageJSON) {
@@ -55,7 +106,7 @@ module.exports = function (program, output, manifestFolder, packageJSON) {
     process.exit(1)
   }
 
-  return function webpackConfig (file, commandIdentifier) {
+  return function webpackConfig (file, commandIdentifier, sketchVersion) {
     var basename = path.basename(file)
 
     var plugins = userDefinedWebpackConfig.plugins || []
@@ -73,12 +124,9 @@ module.exports = function (program, output, manifestFolder, packageJSON) {
       )
     }
 
-    if (commandIdentifier && program.run) {
+    if (program.run && commandIdentifier) {
       plugins.push(
-        new SketchCommandPlugin({
-          bundleURL: output,
-          commandIdentifier
-        })
+        getCommand(output, commandIdentifier, sketchVersion)
       )
     }
 

--- a/lib/utils/webpackShellPlugin.js
+++ b/lib/utils/webpackShellPlugin.js
@@ -1,0 +1,28 @@
+var exec = require('./exec').exec
+var chalk = require('chalk')
+
+module.exports = function WebpackShellPlugin (options) {
+  return {
+    apply: function (compiler) {
+      compiler.plugin('after-emit', (compilation, callback) => {
+        if (options.script) {
+          exec(options.script, { shell: '/bin/bash' }).then(function (res) {
+            if (res.stderr) {
+              console.error(chalk.red('error') + ' Error while running the command after build')
+              console.error(res.stderr)
+            }
+            res.stdout.split('\\n').map(function (line) { console.log(line) })
+          })
+          .then(callback)
+          .catch(function (err) {
+            console.error(chalk.red('error') + ' Error while running the command after build')
+            console.error(err)
+            callback()
+          })
+        } else {
+          callback()
+        }
+      })
+    }
+  }
+}


### PR DESCRIPTION
- In Sketch 43, calling `sketchtool run` would steal focus from your terminal / text editor / editor to Sketch, which is a crappy developer experience.
- I made `run-sketch-command`, which approximates the behavior of `sketchtool run`, using CocoaScript
- Sketch 44 breaks `run-sketch-command`, so we want to fallback to `sketchtool run` for that version
- Sketch 45 introduces a `--without-activating` flag for `sketchtool run`

This should work for each target (test it out by editing `sketchPath` in your `~/.skpmrc` file), but I only have 43 + 45 on my Mac so I'd love it if someone tested it out before merging.

needed to fix https://github.com/airbnb/react-sketchapp/issues/72