### PR TITLE
Fix result logging of shell plugin

### DIFF
--- a/lib/utils/webpackShellPlugin.js
+++ b/lib/utils/webpackShellPlugin.js
@@ -11,7 +11,9 @@ module.exports = function WebpackShellPlugin (options) {
               console.error(chalk.red('error') + ' Error while running the command after build')
               console.error(res.stderr)
             }
-            res.stdout.split('\\n').map(function (line) { console.log(line) })
+            if (res.stdout.trim().length > 0) {
+              res.stdout.trim().split('\n').map(function (line) { console.log(line) })
+            }
           })
           .then(callback)
           .catch(function (err) {


### PR DESCRIPTION
`sketchtool run` mostly just output a blank line, which makes `skpm build --run` output two extra blank lines for each command

```sh
$ skpm build --run
[1/2] 🖨  Copied src/manifest.json in 4ms



[2/2] 🛠  Built ./index.js in 704ms
success Plugin built
```

Trimming the unnecessary blank lines will make the results look better

```sh
$ skpm build --run
[1/2] 🖨  Copied src/manifest.json in 5ms
[2/2] 🔨  Built ./index.js in 649ms
success Plugin built
```