### PR TITLE
Avoid mutating `userDefinedWebpackConfig.plugins` in webpack configuration

### DIFF
--- a/lib/utils/webpackConfig.js
+++ b/lib/utils/webpackConfig.js
@@ -163,7 +163,10 @@ module.exports = function getWebpackConfig(
   ) {
     const basename = path.basename(file)
 
-    let plugins = userDefinedWebpackConfig.plugins || []
+    let plugins = []
+    if (userDefinedWebpackConfig.plugins) {
+      plugins = [...plugins, ...userDefinedWebpackConfig.plugins]
+    }
 
     if (commandIdentifiers) {
       plugins.push(


### PR DESCRIPTION
Fixes #73.

Introduced change to avoid mutating `userDefinedWebpackConfig.plugins` in webpack configuration routine.

I used array spread syntax. According to http://node.green/#ES2015-syntax-spread-------operator-with-arrays--in-function-calls it's available in node 6. It's also running successfully in my node 6.11.2 environment.