### PR TITLE
Exclude `.json` from file-loader's test

### DIFF
--- a/skpm-builder/src/utils/resourceLoader.js
+++ b/skpm-builder/src/utils/resourceLoader.js
@@ -1,6 +1,6 @@
 import path from 'path'
 
-const fileRegex = /^(?!.*\.(jsx?|tsx?)$).*/ // match everything except .jsx? and .tsx?
+const fileRegex = /^(?!.*\.(jsx?|tsx?|json)$).*/ // match everything except .jsx? and .tsx? and json
 
 const commandResourceLoader = {
   test: fileRegex,
@@ -12,9 +12,9 @@ const commandResourceLoader = {
         return path.join('..', 'Resources', '_webpack_resources', url)
       },
       publicPath(url) {
-        return `"file://" + context.plugin.urlForResourceNamed("${url.split(
-          '../Resources/'
-        )[1]}").path()`
+        return `"file://" + context.plugin.urlForResourceNamed("${
+          url.split('../Resources/')[1]
+        }").path()`
       },
     },
   },


### PR DESCRIPTION
Fixes #93.

I fixed `test` of `file-loader` settings. Because the json file was included in the file-loader's reading target. 