### PR TITLE
Explicitly use posix version of path.join in resourceLoader

### DIFF
--- a/packages/builder/src/utils/resourceLoader.js
+++ b/packages/builder/src/utils/resourceLoader.js
@@ -9,7 +9,7 @@ const commandResourceLoader = {
     query: {
       raw: true,
       outputPath(url) {
-        return path.join('..', 'Resources', '_webpack_resources', url)
+        return path.posix.join('..', 'Resources', '_webpack_resources', url)
       },
       publicPath(url) {
         return `"file://" + context.plugin.urlForResourceNamed("${url.split(


### PR DESCRIPTION
Fixes #111.