### PR TITLE
Fixed uglify webpack plugin for production

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -110,7 +110,7 @@ export default function getWebpackConfig(
 
     if (isProd) {
       plugins.push(
-        Uglify({
+        new Uglify({
           uglifyOptions: {
             mangle: {
               // @see https://bugs.webkit.org/show_bug.cgi?id=171041


### PR DESCRIPTION
Here `Uglify` is a class, so it's required to `new` it.

Original exception:
```
[1/2] 🖨  Copied src/manifest.json in 49ms
(node:2593) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: Cannot call a class as a function
(node:2593) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

~~Even though it fixes exception, I didn't get minified output. But that's for another PR.~~
Nevermind, seems that's due to my TypeScript usage, have deal with it inside `webpack.skpm.config.js`.