### PR TITLE
Add `"sketch"` as priority mainField to webpack config

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -132,6 +132,7 @@ export default function getWebpackConfig(
         rules,
       },
       resolve: {
+        mainFields: ['sketch', 'browser', 'module', 'main'],
         extensions: ['.sketch.js', '.js'],
         modules: [
           'node_modules',


### PR DESCRIPTION
This is highly useful to achieve similar goals as `.sketch.js` extension. For isomorphic libraries it's often easier to add explicit field over pointing main/module to extension-less path (to allow `.sketch.js` resolution).

Before this PR you were using default `mainFields: ['browser', 'module', 'main']` setting.