### PR TITLE
remove incorrect character from changelog

### DIFF
--- a/packages/builder/changelog.json
+++ b/packages/builder/changelog.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [],
-  "releases": {\
+  "releases": {
     "0.5.12": ["[New] Resolve the `sketch` field in priority (Thanks @Andarist)"],
     "0.5.11": ["[New] Add `process.type = 'sketch'`"],
     "0.5.10": [


### PR DESCRIPTION
While using airbnb/react-sketchapp I was faced by this error from dependecy skpm, there's a slash that crash's the app.