### PR TITLE
Add `"sketch"` also as priority aliasField to webpack config

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -133,6 +133,7 @@ export default function getWebpackConfig(
       },
       resolve: {
         mainFields: ['sketch', 'browser', 'module', 'main'],
+        aliasFields: ['sketch', 'browser'],
         extensions: ['.sketch.js', '.js'],
         modules: [
           'node_modules',


### PR DESCRIPTION
I've slightly misunderstood how `mainFields` work in webpack (I had no idea `aliasFields` exists).

Both allow slightly different way of overriding files and both are useful, so IMHO it would be good to use both (similarly to how `"browser"` is included by default in both)