### PR TITLE
ci: test on Node.js and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - "8"
-  - "9"
+  - "10"
+  - "node"
 
 os:
   - osx


### PR DESCRIPTION
We should only test against even releases which become LTS and the current latest / stable (fail early).

Node.js 9 has already reached its EOL, see https://github.com/nodejs/Release/blob/master/README.md