### PR TITLE
Fix cli bug where spinner overwrites prompt

### DIFF
--- a/packages/skpm/src/commands/publish.js
+++ b/packages/skpm/src/commands/publish.js
@@ -255,7 +255,7 @@ export default asyncCommand({
         repo
       )
       if (!upstreamPluginJSON.existingPlugin) {
-        spinner.stop()
+        if (spinner) spinner.stop()
         const { addToRegistry } = await prompt({
           type: 'confirm',
           name: 'addToRegistry',

--- a/packages/skpm/src/commands/publish.js
+++ b/packages/skpm/src/commands/publish.js
@@ -124,16 +124,23 @@ export default asyncCommand({
 
     let tag = skpmConfig.version
 
-    const spinner = ora({
-      text: `Checking if \`${repo}\` is accessible`,
-      color: 'magenta',
-    }).start()
+    let spinner = new ora()
 
     function print(text) {
       if (process.env.CI) {
         console.log(text)
       } else {
-        spinner.text = text
+        if (spinner) {
+          spinner.text = text
+          if (!spinner.isSpinning) {
+            spinner.start()
+          }
+        } else {
+          spinner = new ora({
+            text,
+            color: 'magenta',
+          }).start()
+        }
       }
     }
 
@@ -250,6 +257,7 @@ export default asyncCommand({
         repo
       )
       if (!upstreamPluginJSON.existingPlugin) {
+        spinner.stop()
         const { addToRegistry } = await prompt({
           type: 'confirm',
           name: 'addToRegistry',

--- a/packages/skpm/src/commands/publish.js
+++ b/packages/skpm/src/commands/publish.js
@@ -1,4 +1,4 @@
-import ora from 'ora'
+import Ora from 'ora'
 import path from 'path'
 import fs from 'fs'
 import xml2js from 'xml2js'
@@ -124,19 +124,17 @@ export default asyncCommand({
 
     let tag = skpmConfig.version
 
-    let spinner = new ora()
+    let spinner = null
 
     function print(text) {
       if (process.env.CI) {
         console.log(text)
-      } else {
-        if (spinner) {
-          spinner.text = text
-          if (!spinner.isSpinning) {
-            spinner.start()
-          }
+      } else if (spinner) {
+        spinner.text = text
+        if (!spinner.isSpinning) {
+          spinner.start()
         } else {
-          spinner = new ora({
+          spinner = new Ora({
             text,
             color: 'magenta',
           }).start()


### PR DESCRIPTION
When running `skpm publish <version>` for the first time, and plugin is not on directory yet, it seems to be checking infinitely. This just a cosmetic issue, however: the spinner overwrites and hides the prompt in terminal.

This is fixed by moving the creation of the spinner instance into the `print()` function, allowing you to stop the spinner at any given point, clearing it, or even declaring it null. The `print()` function will always check if the `spinner` variable is truthy, and declare `new Ora()` with default settings and text passed into print and restart the spinner.

Closes: #208