### PR TITLE
Use a blank message for missing arguments

### DIFF
--- a/packages/skpm/src/index.js
+++ b/packages/skpm/src/index.js
@@ -64,5 +64,5 @@ For help with a specific command, enter:
   )
   .help()
   .alias('h', 'help')
-  .demandCommand()
+  .demandCommand(1,'')
   .strict().argv


### PR DESCRIPTION
Fixes #234 

Since we show a help text when running with no arguments, having an extra error message felt a bit rude