### PR TITLE
Remove logic for detecting conflicts in files output in the plugin bundle

### DIFF
--- a/packages/builder/src/build.js
+++ b/packages/builder/src/build.js
@@ -140,18 +140,8 @@ async function copyManifest(manifestJSON) {
       }
     }
 
-    const scripts = {}
     copy.commands = manifestJSON.commands.map(command => {
       const script = command.script.replace(/\.(?!js)|\//g, '_')
-      if (scripts[script]) {
-        console.error(
-          `${chalk.red('error')} ${command.script} conflicts with ${
-            scripts[script]
-          } in the plugin bundle`
-        )
-        process.exit(1)
-      }
-      scripts[script] = command.script
       return { ...command, script }
     })
 


### PR DESCRIPTION
This is to revert [`6ea55af`](https://github.com/skpm/skpm/pull/241/commits/6ea55afdf2e729f776a6525e5afa5a56f4013476), which was an attempt to detect conflicts in files output in the plugin bundle. The logic is erroneous because it also disallows commands from having the same `script` _intentionally_. For example, we could have commands with the same `script` but a different `handler`.