### PR TITLE
Remove node entry from webpackConfig

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -168,6 +168,7 @@ export default function getWebpackConfig(
           : path.join(output, 'Contents', 'Resources'),
       },
       plugins,
+      ...(entry.isPluginCommand ? { node: false } : null),
     }
 
     if (userDefinedWebpackConfig) {

--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -168,7 +168,6 @@ export default function getWebpackConfig(
           : path.join(output, 'Contents', 'Resources'),
       },
       plugins,
-      node: !entry.isPluginCommand,
     }
 
     if (userDefinedWebpackConfig) {


### PR DESCRIPTION
Making `node: true` in a Webpack config is [not valid](https://webpack.js.org/configuration/node/). This throws warnings.

This PR proposes that the flag be removed or replaced with a correct alternative. It does nothing in its current state.