### PR TITLE
feat: handle es6 module stubbing

### DIFF
--- a/packages/test-runner/lib/utils/loader-hacks/babel-loader.hack.js
+++ b/packages/test-runner/lib/utils/loader-hacks/babel-loader.hack.js
@@ -5,6 +5,7 @@ module.exports = function hackBabelConfig(skpmConfig, loader) {
     loader.options = {}
   }
   loader.options.plugins = [
+    '@babel/plugin-transform-modules-commonjs',
     [require('./globals-babel-plugin'), skpmConfig.test],
   ].concat(loader.options.plugins || [])
 }

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/skpm/skpm/tree/master/packages/test-runner#readme",
   "dependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.6.0",
     "@skpm/builder": "^0.7.0",
     "@skpm/internal-utils": "^0.1.14",
     "chalk": "^2.4.1",


### PR DESCRIPTION
add @babel/plugin-transform-modules-commonjs for test-runner's babel build

fixes #250 