### PR TITLE
Add jsx extension to Webpack config

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -129,7 +129,7 @@ export default function getWebpackConfig(
       resolve: {
         mainFields: ['sketch', 'browser', 'module', 'main'],
         aliasFields: ['sketch', 'browser'],
-        extensions: ['.sketch.js', '.js'],
+        extensions: ['.sketch.js', '.js', '.sketch.jsx', '.jsx'],
         modules: [
           'node_modules',
           path.join(__dirname, '..', '..', 'node_modules'),


### PR DESCRIPTION
(tested locally and seems to build/resolve fine, but having strange issues with latest `skpm` version and `react-sketchapp` – says built, but plugin hasn't updated).

I've tested patching `webpackConfig.js` with the PR diff in `@skpm/builder@0.4.0` which I have pinned though and that works.

fixes #270 