### PR TITLE
fix path in Windows

### DIFF
--- a/packages/builder/src/build.js
+++ b/packages/builder/src/build.js
@@ -231,7 +231,7 @@ function checkEnd() {
 }
 
 async function copyAsset(asset) {
-  const dirWithoutFirst = asset
+  const dirWithoutFirst = path.normalize(asset)
     .split(path.sep)
     .splice(1)
     .join(path.sep)


### PR DESCRIPTION
In Windows, the value of `asset` will be like `assets/logo.png`, and `path.sep` is `\`, so it's not work.