### PR TITLE
Add babel transform runtime plugin

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -26,6 +26,12 @@ module.exports = function buildSkpmPreset(api, options) {
       '@babel/plugin-syntax-async-generators',
       '@babel/plugin-proposal-object-rest-spread',
       '@babel/plugin-proposal-export-namespace-from',
+      [
+        '@babel/plugin-transform-runtime',
+        {
+          regenerator: true,
+        },
+      ],
     ],
   }
 }

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0"
   },


### PR DESCRIPTION
After babel use `@babel/plugin-syntax-async-generators` plugin transform `async/await` syntax, it miss `regeneratorRuntime` variable define in the compiled file. We need also add runtime module into it.
 
close https://github.com/skpm/sketch-module-web-view/issues/145 when pull request merged.

btw, an easy command file can take you have a test. It shows nothing with older version and show "Plugin Loaded" message after 5 seconds with fixed version.

```js
import UI from "sketch/ui";

function sleep(second) {
  return new Promise(resolve => setTimeout(resolve, second * 1000));
}

export default async function() {
  await sleep(5);
  UI.message('Plugin Loaded!');
}
```