### PR TITLE
Related issue 282: Fix script destination for files with extensions .ts .tsx .jsx

### DIFF
--- a/packages/builder/src/build.js
+++ b/packages/builder/src/build.js
@@ -141,7 +141,9 @@ async function copyManifest(manifestJSON) {
     }
 
     copy.commands = manifestJSON.commands.map(command => {
-      const script = command.script.replace(/\.(?!js)|\//g, '_')
+      const script = command.script
+        .replace(/\.(?!j|tsx?$)|\//g, '_')
+        .replace(/j|tsx?$/, 'js')
       return { ...command, script }
     })
 
@@ -231,7 +233,8 @@ function checkEnd() {
 }
 
 async function copyAsset(asset) {
-  const dirWithoutFirst = path.normalize(asset)
+  const dirWithoutFirst = path
+    .normalize(asset)
     .split(path.sep)
     .splice(1)
     .join(path.sep)


### PR DESCRIPTION
### Expectations:
1. I set up typescript for the project
2. I would like to use .ts extension for the scripts as a manifest script
3. I am waiting that everithing will going correct

### Reality:
If I try to use .ts scripts inside manifest, build replace them to incorrect script name:
```json
{
  "name": "Name",
  "commands": [
    {
      "name": "Run",
      "identifier": "run",
      "script": "./run.ts"
    }
  ]
}
```
Will replace to:
```json
{
  "name": "Name",
  "commands": [
    {
      "name": "Run",
      "identifier": "run",
      "script": "./__run_ts"
    }
  ]
}
```

## Fix works such way:
1. entry `./run.js` -> destination `__run.js`
2. entry `./run.ts` -> destination `__run.js`
3. entry `./run.jsx` -> destination `__run.js`
4. entry `./run.tsx` -> destination `__run.js`