### PR TITLE
Fix regex script rewriting

### DIFF
--- a/packages/builder/src/build.js
+++ b/packages/builder/src/build.js
@@ -142,8 +142,8 @@ async function copyManifest(manifestJSON) {
 
     copy.commands = manifestJSON.commands.map(command => {
       const script = command.script
-        .replace(/\.(?!j|tsx?$)|\//g, '_')
-        .replace(/j|tsx?$/, 'js')
+        .replace(/\.(?![jt]sx?$)|\//g, '_')
+        .replace(/[jt]sx?$/, 'js')
       return { ...command, script }
     })
 


### PR DESCRIPTION
Previous change rewrites first "j" in filename:
`("my-command.js").replace(/j|tsx?$/, 'js') === "my-command.jss"`
`("j-command.ts").replace(/j|tsx?$/, 'js') === "js-command.ts"`