### PR TITLE
[BugFix] command filename incorrect for typescript project

### DIFF
--- a/packages/builder/src/utils/webpackConfig.js
+++ b/packages/builder/src/utils/webpackConfig.js
@@ -161,7 +161,7 @@ export default function getWebpackConfig(
         },
       ],
       output: {
-        filename: entry.script.replace(/\.(?!js)|\//g, '_'),
+        filename: entry.script.replace(/\.(?![jt]sx?$)|\//g, '_').replace(/[jt]sx?$/, 'js'),
         library: entry.isPluginCommand ? 'exports' : undefined,
         path: entry.isPluginCommand
           ? path.join(output, 'Contents', 'Sketch')


### PR DESCRIPTION
#283 change `.ts` to `.js` in manifest.json, but it forget change output filename, so output filename also is the old style `_ts`. We need modify them both so plugin can find file correctly.

I create a demo repo https://github.com/lizheming/skpm-builder-bug to reproduce it. You can clone it and run `npm run build` then you can find the problem.