### PR TITLE
fix release page URL

### DIFF
--- a/packages/skpm/src/commands/publish.js
+++ b/packages/skpm/src/commands/publish.js
@@ -358,7 +358,7 @@ export default asyncCommand({
     console.log(`${skpmConfig.name}@${tag.replace('v', '')}`)
 
     if (argv.openRelease) {
-      open(`https://github.com/${repo}/tag/${tag.replace('v', '')}`)
+      open(`https://github.com/${repo}/releases/tag/${tag}`)
     }
   },
 })


### PR DESCRIPTION
Original URL was not found.

Let's say my plugin's repo is `griffin-stewie/PluginsNameList`

- Not found
    - https://github.com/griffin-stewie/PluginsNameList/tag/0.0.3
- Correct
    - https://github.com/griffin-stewie/PluginsNameList/releases/tag/v0.0.3