### PR TITLE
bump sketch-polyfill-fetch ^0.4.6 -> ^0.5.2

### DIFF
--- a/packages/builder/changelog.json
+++ b/packages/builder/changelog.json
@@ -1,6 +1,9 @@
 {
   "unreleased": [],
   "releases": {
+    "0.8.0": [
+      "[Fixed] Update sketch-polyfill-fetch to 0.5"
+    ],
     "0.7.11": [
       "[Fixed] Script destination for files with extensions .ts .tsx .jsx"
     ],

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skpm/builder",
-  "version": "0.7.11",
+  "version": "0.8.0",
   "description": "A script to build and link sketch plugins",
   "main": "lib/index.js",
   "publishConfig": {
@@ -53,7 +53,7 @@
     "mkdirp": "^0.5.1",
     "parse-author": "2.0.0",
     "semver": "^6.0.0",
-    "sketch-polyfill-fetch": "^0.4.3",
+    "sketch-polyfill-fetch": "^0.5.2",
     "terser-webpack-plugin": "^1.2.3",
     "webpack": "^4.29.6",
     "webpack-merge": "^4.2.1",

--- a/packages/test-runner/CHANGELOG.json
+++ b/packages/test-runner/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [],
   "releases": {
+    "0.5.0": ["[Improved] Update @skpm/builder to 0.8"],
     "0.4.1": ["[Improved] Allow stubbing (Thanks @FRSgit!)"],
     "0.4.0": [
       "[Improved] Refactor watch mode to make it less memory intensive",

--- a/packages/test-runner/package.json
+++ b/packages/test-runner/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/skpm/skpm/tree/master/packages/test-runner#readme",
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-    "@skpm/builder": "^0.7.0",
+    "@skpm/builder": "^0.8.0",
     "@skpm/internal-utils": "^0.1.14",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",

--- a/template/package.json
+++ b/template/package.json
@@ -21,6 +21,6 @@
     "postinstall": "npm run build && skpm-link"
   },
   "devDependencies": {
-    "@skpm/builder": "^0.7.0"
+    "@skpm/builder": "^0.8.0"
   }
 }


### PR DESCRIPTION
`@skpm/builder` has an old version of the `sketch-polyfill-fetch` library, since versions starting with `^0` are not treated the same way as `^1`; meaning the latest version of the fetch polyfill will currently be `0.4.x`.

Bumped the version of `sketch-polyfill-fetch` in `@skpm/builder` to get the [bugfix from 0.5.2](https://github.com/skpm/sketch-polyfill-fetch/commit/63edfb64e1480e2097e6d3d4e2eb21020a775dab) which prevents certain cache settings.

Bumped `@skpm/builder` and `@skpm/test-runner` to new minor versions accordingly.